### PR TITLE
fix: observer remove function bug

### DIFF
--- a/12_observer/121_observer/observer.go
+++ b/12_observer/121_observer/observer.go
@@ -12,6 +12,7 @@ type ISubject interface {
 // IObserver 观察者
 type IObserver interface {
 	Update(msg string)
+	GetName() string
 }
 
 // Subject Subject
@@ -27,7 +28,7 @@ func (sub *Subject) Register(observer IObserver) {
 // Remove 移除观察者
 func (sub *Subject) Remove(observer IObserver) {
 	for i, ob := range sub.observers {
-		if ob == observer {
+		if ob.GetName() == observer.GetName() {
 			sub.observers = append(sub.observers[:i], sub.observers[i+1:]...)
 		}
 	}
@@ -41,17 +42,29 @@ func (sub *Subject) Notify(msg string) {
 }
 
 // Observer1 Observer1
-type Observer1 struct{}
+type Observer1 struct {
+	Name string
+}
 
 // Update 实现观察者接口
 func (Observer1) Update(msg string) {
-	fmt.Printf("Observer1: %s", msg)
+	fmt.Printf("Observer1: %s\n", msg)
+}
+
+func (o Observer1) GetName() string {
+	return o.Name
 }
 
 // Observer2 Observer2
-type Observer2 struct{}
+type Observer2 struct {
+	Name string
+}
 
 // Update 实现观察者接口
 func (Observer2) Update(msg string) {
 	fmt.Printf("Observer2: %s", msg)
+}
+
+func (o Observer2) GetName() string {
+	return o.Name
 }

--- a/12_observer/121_observer/observer_test.go
+++ b/12_observer/121_observer/observer_test.go
@@ -8,3 +8,19 @@ func TestSubject_Notify(t *testing.T) {
 	sub.Register(&Observer2{})
 	sub.Notify("hi")
 }
+
+func TestSubject_Remove(t *testing.T) {
+	obs1 := &Observer1{
+		Name: "obs1",
+	}
+	obs2 := &Observer2{
+		Name: "obs2",
+	}
+
+	sub := &Subject{}
+	sub.Register(obs1)
+	sub.Register(obs2)
+	sub.Notify("hi")
+	sub.Remove(obs2)
+	sub.Notify("hi")
+}


### PR DESCRIPTION
func (sub *Subject) Remove(observer IObserver){}中ob == observer的比较方法我认为不太合理并且存在bug，Observer1和Observer2中没有其他字段且都为{}，导致remove中会删除所有观察者，进而导致panic。

改进：只要向ObserverX中添加成员变量即可解决，我统一提供了GetName()方法进行比较。

望采纳～