### PR TITLE
fix: slice range bug in remove function

### DIFF
--- a/12_observer/121_observer/observer.go
+++ b/12_observer/121_observer/observer.go
@@ -26,9 +26,10 @@ func (sub *Subject) Register(observer IObserver) {
 
 // Remove 移除观察者
 func (sub *Subject) Remove(observer IObserver) {
-	for i, ob := range sub.observers {
-		if ob == observer {
+	for i := 0; i < len(sub.observers); i++ {
+		if sub.observers[i] == observer {
 			sub.observers = append(sub.observers[:i], sub.observers[i+1:]...)
+			i--
 		}
 	}
 }

--- a/12_observer/121_observer/observer_test.go
+++ b/12_observer/121_observer/observer_test.go
@@ -8,3 +8,16 @@ func TestSubject_Notify(t *testing.T) {
 	sub.Register(&Observer2{})
 	sub.Notify("hi")
 }
+
+func TestSubject_Remove(t *testing.T) {
+	obs1 := &Observer2{}
+	obs2 := &Observer1{}
+	obs3 := &Observer1{}
+	sub := &Subject{}
+	sub.Register(obs1)
+	sub.Register(obs2)
+	sub.Register(obs3)
+	sub.Notify("hi")
+	sub.Remove(obs2)
+	sub.Notify("hi")
+}


### PR DESCRIPTION
Golang中slice删除元素时候使用range方法会产生panic，i的下标可能已经超过了len(sub.observers)，导致sub.observers[i+1:]越界，修改成了一种更安全的遍历方式～